### PR TITLE
.cirrus.yml: fix artifacs instruction usage

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -250,8 +250,14 @@ setup_task:
     # ports-mgmt/poudriere-devel.
     poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PACKAGE_BRANCH}" -t -C "${PD_ORIGIN}"
   copy_packages_script: |
-    mkdir -p "${PD_WORKDIR}/packages"
-    cp -RL "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}" "${PD_WORKDIR}/packages/"
+
+    mkdir -p "${PD_WORKDIR}/packages/${PD_JAIL_NAME}/All"
+    D=`realpath "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/All"`
+    cp ${D}/* "${PD_WORKDIR}/packages/${PD_JAIL_NAME}/All"
+    for F in meta.conf meta.txz packagesite.txz; do
+      F=`realpath "${D}/${F}"`
+      cp "${F}" "${PD_WORKDIR}/packages/${PD_JAIL_NAME}"
+    done
     ls -alR "${PD_WORKDIR}/packages"
 
   packages_artifacts: |
@@ -276,3 +282,67 @@ setup_task:
     log_artifacts:
       path: "logs/*.log"
       type: text/plain
+
+test_task:
+  matrix:
+    - compute_engine_instance:
+        image_project: freebsd-org-cloud-dev
+        image: family/freebsd-13-0
+        platform: freebsd
+
+  define_common_variables_script: |
+
+    # e.g. 122
+    PD_VERSION_SHORT=`uname -r | sed -e 's/-.*//' -e 's/\.//'`
+
+    # e.g. amd64
+    PD_MACHINE=`uname -m`
+
+    # e.g. 12.2-RELEASE
+    PD_RELEASE_NAME=`uname -r | sed -e 's/-p.*//'`
+
+    # e.g. 122amd64
+    PD_JAIL_NAME="${PD_VERSION_SHORT}${PD_MACHINE}"
+
+    cat << __EOF__ >> ${CIRRUS_ENV}
+    PD_VERSION_SHORT=${PD_VERSION_SHORT}
+    PD_MACHINE=${PD_MACHINE}
+    PD_RELEASE_NAME=${PD_RELEASE_NAME}
+    PD_JAIL_NAME=${PD_JAIL_NAME}
+    __EOF__
+    cat ${CIRRUS_ENV}
+
+  show_env_script: |
+    env | sort
+
+  download_packages_script: |
+    fetch -o ${CIRRUS_WORKING_DIR}/packages.zip \
+      "https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/packages.zip"
+    (cd ${CIRRUS_WORKING_DIR} && unzip packages.zip)
+    ls -alR ${CIRRUS_WORKING_DIR}/packages
+
+  setup_pkg_conf: |
+    mkdir -p /usr/local/etc/pkg/repos
+    cat < __EOF__ > /usr/local/etc/pkg/repos/local.conf
+    local: {
+      URL: "file://${CIRRUS_WORKING_DIR}/packages/${PD_JAIL_NAME}"
+      ENABLED: yes
+    }
+    __EOF__
+    cat /usr/local/etc/pkg/repos/local.conf
+
+  install_packages_script: |
+
+    # create a list of all packages in the repository
+    PD_ALL_ORIGIN=`echo */* | sed -e 's|/[[:space:]]| |g' -e 's|/$||'`
+    echo "PD_ALL_ORIGIN=${PD_ALL_ORIGIN}"
+    for D in ${PD_ALL_ORIGIN}; do
+      PD_FLAVORS=`make -V FLAVORS -C "${D}"`
+      echo "PD_FLAVORS=${PD_FLAVORS}"
+      for F in ${PD_FLAVORS}; do
+        echo "FLAVOR=${F}"
+        P=`make -V PKGNAME -C "${D}" FLAVOR="${F}"`
+        echo "${P}"
+        pkg install --repository local "${P}"
+      done
+    done

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -90,7 +90,7 @@ build_task:
 
     # define common variavles used in *_script. remember to export variables
     # at the end of this script.
-    PD_WORKDIR="$CIRRUS_WORKING_DIR}"
+    PD_WORKDIR="${CIRRUS_WORKING_DIR}"
     PD_BASEFS="${PD_WORKDIR}/poudriere"
     PD_CCACHE_DIR=/var/cache/ccache
     PD_REQUIRED_PACKAGES="ports-mgmt/poudriere-devel ports-mgmt/portshaker ports-mgmt/portshaker-config git-lite"
@@ -252,11 +252,12 @@ build_task:
   copy_packages_script: |
 
     mkdir -p "${PD_WORKDIR}/packages/${PD_JAIL_NAME}/All"
+    ls -alR     "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}"
     D=`realpath "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/All"`
     cp ${D}/* "${PD_WORKDIR}/packages/${PD_JAIL_NAME}/All"
-    ls -al ${PD_WORKDIR}/packages/${PD_JAIL_NAME}
+    ls -alR "${PD_WORKDIR}/packages/${PD_JAIL_NAME}"
     for F in meta.conf meta.txz packagesite.txz; do
-      F=`realpath "${PD_WORKDIR}/packages/${PD_JAIL_NAME}/${F}"`
+      F=`realpath "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/${F}"`
       cp "${F}" "${PD_WORKDIR}/packages/${PD_JAIL_NAME}"
     done
     ls -alR "${PD_WORKDIR}/packages"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,11 +1,9 @@
 # TODOs
 #
-# * support "Re-run with Terminal Access"
-#   https://medium.com/cirruslabs/introducing-cirrus-terminal-a-simple-way-to-get-ssh-like-access-to-your-tasks-1def0449065d
-# * publish packages when releasing
+# * publish packages on GitHub Pages when releasing
 # * support quaterly/latest ports
 # * support other FreeBSD releases
-# * sign the packages
+# * generate a kye and sign the packages with it
 #
 # known issues
 #
@@ -264,7 +262,10 @@ build_task:
 
     # can be downloaded at:
     # https://api.cirrus-ci.com/v1/artifact/build/<CIRRUS_BUILD_ID>/<ARTIFACTS_NAME>.zip
-    path: "packages/*"
+    # path: "packages/*"
+    #
+    # Error from upload stream: rpc error: code = Unknown desc =
+    path: "packages/*.txz"
 
   on_failure:
     show_error_log_script: |
@@ -356,6 +357,8 @@ test_task:
     # create a list of all packages in the repository
     PD_ALL_ORIGIN=`echo */* | sed -e 's|/[[:space:]]| |g' -e 's|/$||'`
     echo "PD_ALL_ORIGIN=${PD_ALL_ORIGIN}"
+
+    # install ${PD_ALL_ORIGIN}
     for D in ${PD_ALL_ORIGIN}; do
       PD_FLAVORS=`make -V FLAVORS -C "${D}"`
       echo "PD_FLAVORS=${PD_FLAVORS}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,14 +19,14 @@ setup_task:
         image: family/freebsd-13-0
         platform: freebsd
         cpu: 4
-        memory: 4
+        memory: 8
         disk: 80
-    - freebsd_instance:
+    - compute_engine_instance:
         image_project: freebsd-org-cloud-dev
         image: family/freebsd-12-2
         platform: freebsd
         cpu: 4
-        memory: 4
+        memory: 8
         disk: 80
   define_common_variables_script: |
     PD_WORKDIR="/tmp"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,11 +34,14 @@ setup_task:
         cpu: 4
         memory: 8
         disk: 80
-  # increase timeout_in. in most cases, build will not finish 60m, which is
+  # increase timeout_in. in most cases, build will not finish in 60m, which is
   # the default. the default is not documented at
   # https://cirrus-ci.org/guide/writing-tasks/, but at https://cirrus-ci.org/faq/
   timeout_in: 120m
   define_common_variables_script: |
+
+    # define common variavles used in *_script. remember to export variables
+    # at the end of this script.
     PD_WORKDIR="/tmp"
 
     PD_BASEFS="${PD_WORKDIR}/poudriere"
@@ -46,7 +49,8 @@ setup_task:
     PD_REQUIRED_PACKAGES="ports-mgmt/poudriere-devel ports-mgmt/portshaker ports-mgmt/portshaker-config git-lite"
 
     # the branch to use for the FreeBSD ports tree
-    # see https://github.com/freebsd/freebsd-ports/branches
+    # see https://github.com/freebsd/freebsd-ports/branches for available
+    # branches
     PD_FREEBSD_PORTS_BRANCH="2021Q3"
 
     # the branch to use for the FreeBSD package tree
@@ -69,6 +73,8 @@ setup_task:
     # e.g 122amd64-default
     PD_BUILD_NAME="${PD_JAIL_NAME}-${PD_PORTS_NAME}"
 
+    # `export` the variables so that other scripts can use them.
+    #
     # note that the ${CIRRUS_ENV} file is NOT a shell script. empty line is
     # not allowed. value should NOT be quoted (i.e. NOT `foo="bar buz"`. use
     # `foo=bar buz` instead).
@@ -84,6 +90,7 @@ setup_task:
     PD_PORTS_NAME=${PD_PORTS_NAME}
     PD_BUILD_NAME=${PD_BUILD_NAME}
     PD_FREEBSD_PORTS_BRANCH=${PD_FREEBSD_PORTS_BRANCH}
+    PD_FREEBSD_PACKAGE_BRANCH=${PD_FREEBSD_PACKAGE_BRANCH}
     __EOF__
     cat ${CIRRUS_ENV}
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -303,7 +303,7 @@ generate_repo_task:
 
 test_task:
   depends_on:
-    - generate_packagesite_txz
+    - generate_repo_task
   matrix:
     - compute_engine_instance:
         image_project: freebsd-org-cloud-dev

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -303,7 +303,7 @@ generate_repo_task:
 
 test_task:
   depends_on:
-    - generate_repo_task
+    - generate_repo
   matrix:
     - compute_engine_instance:
         image_project: freebsd-org-cloud-dev

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,159 @@
+# TODOs
+#
+# * support "Re-run with Terminal Access"
+#   https://medium.com/cirruslabs/introducing-cirrus-terminal-a-simple-way-to-get-ssh-like-access-to-your-tasks-1def0449065d
+# * publish packages when releasing
+# * support quaterly/latest ports
+
+freebsd_instance:
+  cpu: 4
+  memory: 4
+
+env:
+  HOME: /root
+  PATH: /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
+  USER: root
+
+setup_task:
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-13-0
+    - freebsd_instance:
+        image_family: freebsd-12-2
+  define_common_variables_script: |
+    PD_BASEFS="/usr/local/poudriere"
+    PD_REQUIRED_PACKAGES="ports-mgmt/poudriere ports-mgmt/portshaker ports-mgmt/portshaker-config git-lite"
+
+    # e.g. 122
+    PD_VERSION_SHORT=`uname -r | sed -e 's/-.*//' -e 's/\.//'`
+
+    # e.g. amd64
+    PD_MACHINE=`uname -m`
+
+    # e.g. 12.2-RELEASE
+    PD_RELEASE_NAME=`uname -r | sed -e 's/-p.*//'`
+
+    # e.g. 122amd64
+    PD_JAIL_NAME="${PD_VERSION_SHORT}${PD_MACHINE}"
+    PD_PORTS_NAME="default"
+
+    # e.g 122amd64-default
+    PD_BUILD_NAME="${PD_JAIL_NAME}-${PD_PORTS_NAME}"
+
+    # note that the ${CIRRUS_ENV} file is NOT a shell script. empty line is
+    # not allowed. value should NOT be quoted (i.e. NOT `foo="bar buz"`. use
+    # `foo=bar buz` instead).
+    cat << __EOF__ >> ${CIRRUS_ENV}
+    PD_BASEFS=${PD_BASEFS}
+    PD_REQUIRED_PACKAGES=${PD_REQUIRED_PACKAGES}
+    PD_VERSION_SHORT=${PD_VERSION_SHORT}
+    PD_MACHINE=${PD_MACHINE}
+    PD_RELEASE_NAME=${PD_RELEASE_NAME}
+    PD_JAIL_NAME=${PD_JAIL_NAME}
+    PD_PORTS_NAME=${PD_PORTS_NAME}
+    PD_BUILD_NAME=${PD_BUILD_NAME}
+    __EOF__
+    cat ${CIRRUS_ENV}
+
+  setup_script: |
+    uname -msr
+    sysctl kern.osreldate
+    env | sort
+
+    # configure _merged_ ports tree
+    cat << __EOF__ > /usr/local/etc/portshaker.conf
+    mirror_base_dir="/var/cache/portshaker"
+    ports_trees="${PD_PORTS_NAME}"
+    default_ports_tree="${PD_BASEFS}/ports/${PD_PORTS_NAME}"
+    default_merge_from="github:freebsd:freebsd-ports:main github:${CIRRUS_REPO_OWNER}:${CIRRUS_REPO_NAME}:${CIRRUS_BRANCH}"
+    fail_on_conflict="y"
+
+    __EOF__
+
+    # configure poudriere
+    cat << __EOF__ > /usr/local/etc/poudriere.conf
+    NO_ZFS=yes
+    BASEFS=${PD_BASEFS}
+    USE_TMPFS=data
+    FREEBSD_HOST=https://download.FreeBSD.org
+    FLAVOR_DEFAULT_ALL=yes
+    DISTFILES_CACHE=${PD_BASEFS}/ports/${PD_PORTS_NAME}/distfiles
+
+    __EOF__
+    cat /usr/local/etc/poudriere.conf
+
+  required_packages_cache:
+    folder: /var/cache/pkg
+    fingerprint_script:
+      - uname -msr
+      - echo 20210909
+    populate_script: |
+      pkg fetch --dependencies --yes ${PD_REQUIRED_PACKAGES}
+
+  required_packages_install_script: |
+    pkg install --yes ${PD_REQUIRED_PACKAGES}
+
+  ports_tree_cache:
+    folder: /var/cache/portshaker/github_freebsd_freebsd-ports_main
+    fingerprint_script:
+      - echo github_freebsd_freebsd-ports_main
+      - echo 20210909
+    populate_script: |
+      time -h portshaker -u github:freebsd:freebsd-ports:main
+
+  ports_tree_install_script: |
+    echo Updating github:${CIRRUS_REPO_OWNER}:${CIRRUS_REPO_NAME}:${CIRRUS_BRANCH}
+    portshaker -u github:${CIRRUS_REPO_OWNER}:${CIRRUS_REPO_NAME}:${CIRRUS_BRANCH}
+
+    # create the merged ports tree
+    time -h portshaker -M
+
+    # create the merged ports tree
+    poudriere ports -c -p ${PD_PORTS_NAME} -M ${PD_BASEFS}/ports/${PD_PORTS_NAME} -m null
+
+    # ensure DISTFILES_CACHE exists
+    mkdir -p ${PD_BASEFS}/ports/${PD_PORTS_NAME}/distfiles
+
+  built_packages_cache:
+    folder: ${PD_BASEFS}/data/packages
+
+  create_jail_script: |
+
+    # cannot cache jails at the moment. see:
+    # https://github.com/freebsd/poudriere/issues/137
+    #
+    # also, the size of ${PD_BASEFS}/jails is too big to cache, and
+    # cirrus-ci refuses to cache
+    poudriere jail -c -j ${PD_JAIL_NAME} -m ftp -v ${PD_RELEASE_NAME}
+
+  build_script: |
+
+    # create artifacts directory
+    #
+    # https://cirrus-ci.org/guide/writing-tasks
+    # "Right now only storing files under $CIRRUS_WORKING_DIR folder as
+    # artifacts is supported with a total size limit of 1G for a community
+    # task"
+    mkdir -p ${CIRRUS_WORKING_DIR}/logs
+
+    # create a list of all packages in the repository
+    ALL_ORIGIN=`echo */* | sed -e 's|/[[:space:]]| |g' -e 's|/$||'`
+
+    poudriere ports -l
+    poudriere jail -l
+
+    # build ALL_ORIGIN
+    echo Building ${ALL_ORIGIN}
+    poudriere bulk -j "${PD_VERSION_SHORT}${PD_MACHINE}" -p ${PD_PORTS_NAME} -t -C ${ALL_ORIGIN}
+
+  on_failure:
+    show_error_log_script: |
+      for F in ${PD_BASEFS}/data/logs/bulk/${PD_BUILD_NAME}/latest/logs/errors/*.log; do
+        echo "${F}"
+        cat ${F}
+      done
+  always:
+    copy_log_script: |
+      cp ${PD_BASEFS}/data/logs/bulk/${PD_BUILD_NAME}/latest/logs/*.log ${CIRRUS_WORKING_DIR}/logs/
+    log_artifacts:
+      path: "logs/*.log"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -251,12 +251,13 @@ setup_task:
     poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PACKAGE_BRANCH}" -t -C "${PD_ORIGIN}"
   copy_packages_script: |
     mkdir -p "${PD_WORKDIR}/packages"
-    cp "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}" "${PD_WORKDIR}/packages/"
+    cp -RL "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}" "${PD_WORKDIR}/packages/"
+    ls -alR "${PD_WORKDIR}/packages"
 
   packages_artifacts: |
 
     # can be downloaded at:
-    # https://api.cirrus-ci.com/v1/artifact/build/<CIRRUS_BUILD_ID>/<TASK_NAME>/<ARTIFACTS_NAME>.zip
+    # https://api.cirrus-ci.com/v1/artifact/build/<CIRRUS_BUILD_ID>/<ARTIFACTS_NAME>.zip
     path: "packages/*"
 
   on_failure:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,7 @@
 #   https://medium.com/cirruslabs/introducing-cirrus-terminal-a-simple-way-to-get-ssh-like-access-to-your-tasks-1def0449065d
 # * publish packages when releasing
 # * support quaterly/latest ports
+# * support other FreeBSD releases
 #
 # known issues
 #
@@ -17,6 +18,11 @@ env:
 
 setup_task:
   matrix:
+    # XXX divide the CI into multiple per-package build using matrix. max
+    # timeout_in for a single task is limited to two hours. because of that,
+    # the build (which takes more than two hours) fails. this is not a
+    # portable, nor a generic solution for other ports.
+    #
     # XXX use compute_engine_instance, instead of freebsd_instance, which is a
     # syntactic sugar. with freebsd_instance, disk parameter is ignored.
     # see https://github.com/cirruslabs/cirrus-ci-docs/issues/911
@@ -27,17 +33,59 @@ setup_task:
         cpu: 4
         memory: 8
         disk: 80
+      env:
+        PD_ORIGIN: devel/riscv32-esp-elf
+        PD_ALLOW_MAKE_JOBS_PACKAGES: "riscv32-esp-elf*"
+
     - compute_engine_instance:
         image_project: freebsd-org-cloud-dev
-        image: family/freebsd-12-2
+        image: family/freebsd-13-0
         platform: freebsd
         cpu: 4
         memory: 8
         disk: 80
+      env:
+        PD_ORIGIN: devel/xtensa-esp32-elf
+        PD_ALLOW_MAKE_JOBS_PACKAGES: "xtensa-esp32-elf*"
+
+    - compute_engine_instance:
+        image_project: freebsd-org-cloud-dev
+        image: family/freebsd-13-0
+        platform: freebsd
+        cpu: 4
+        memory: 8
+        disk: 80
+      env:
+        PD_ORIGIN: devel/xtensa-esp32s2-elf
+        PD_ALLOW_MAKE_JOBS_PACKAGES: "xtensa-esp32s2-elf*"
+
+    - compute_engine_instance:
+        image_project: freebsd-org-cloud-dev
+        image: family/freebsd-13-0
+        platform: freebsd
+        cpu: 4
+        memory: 8
+        disk: 80
+      env:
+        PD_ORIGIN: devel/binutils-esp32s2ulp
+        PD_ALLOW_MAKE_JOBS_PACKAGES: "binutils-esp32s2ulp"
+
+    - compute_engine_instance:
+        image_project: freebsd-org-cloud-dev
+        image: family/freebsd-13-0
+        platform: freebsd
+        cpu: 4
+        memory: 8
+        disk: 80
+      env:
+        PD_ORIGIN: devel/binutils-esp32ulp
+        PD_ALLOW_MAKE_JOBS_PACKAGES: "binutils-esp32ulp"
+
   # increase timeout_in. in most cases, build will not finish in 60m, which is
   # the default. the default is not documented at
   # https://cirrus-ci.org/guide/writing-tasks/, but at https://cirrus-ci.org/faq/
-  timeout_in: 240m
+  # the max timeout_in is two hours.
+  timeout_in: 120m
   define_common_variables_script: |
 
     # define common variavles used in *_script. remember to export variables
@@ -122,6 +170,7 @@ setup_task:
     FLAVOR_DEFAULT_ALL=yes
     DISTFILES_CACHE=${PD_BASEFS}/ports/${PD_PORTS_NAME}/distfiles
     CCACHE_DIR=${PD_CCACHE_DIR}
+    ALLOW_MAKE_JOBS_PACKAGES="${PD_ALLOW_MAKE_JOBS_PACKAGES}"
 
     # increase MAX_FILES. crosstool-NG.sh tries to modify ulimit during the
     # build, which is not allowed.
@@ -188,19 +237,18 @@ setup_task:
     mkdir -p "${CIRRUS_WORKING_DIR}/logs"
 
     # create a list of all packages in the repository
-    PD_ALL_ORIGIN=`echo */* | sed -e 's|/[[:space:]]| |g' -e 's|/$||'`
+    # PD_ALL_ORIGIN=`echo */* | sed -e 's|/[[:space:]]| |g' -e 's|/$||'`
 
     poudriere ports -l
     poudriere jail -l
 
-    # build PD_ALL_ORIGIN
-    echo "Building ${PD_ALL_ORIGIN}"
+    # build PD_ORIGIN
+    echo "Building ${PD_ORIGIN}"
 
-    # do NOT quote PD_ALL_ORIGIN
-    # use -b flag to pre-install binary packages on which ${PD_ALL_ORIGIN}
+    # use -b flag to pre-install binary packages on which ${PD_ORIGIN}
     # depends. it saves time by skipping depended builds. -b flag requires
     # ports-mgmt/poudriere-devel.
-    poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PACKAGE_BRANCH}" -t -C ${PD_ALL_ORIGIN}
+    poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PACKAGE_BRANCH}" -t -C "${PD_ORIGIN}"
 
   on_failure:
     show_error_log_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,7 +67,7 @@ build_task:
         disk: 80
       env:
         PD_ORIGIN: devel/binutils-esp32s2ulp
-        PD_ALLOW_MAKE_JOBS_PACKAGES: "binutils-esp32s2ulp"
+        PD_ALLOW_MAKE_JOBS_PACKAGES: "binutils-esp32s2ulp*"
 
     - compute_engine_instance:
         image_project: freebsd-org-cloud-dev
@@ -78,7 +78,7 @@ build_task:
         disk: 80
       env:
         PD_ORIGIN: devel/binutils-esp32ulp
-        PD_ALLOW_MAKE_JOBS_PACKAGES: "binutils-esp32ulp"
+        PD_ALLOW_MAKE_JOBS_PACKAGES: "binutils-esp32ulp*"
 
   # increase timeout_in. in most cases, build will not finish in 60m, which is
   # the default. the default is not documented at
@@ -266,7 +266,7 @@ build_task:
     # path: "packages/*"
     #
     # Error from upload stream: rpc error: code = Unknown desc =
-    path: "packages/*"
+    path: "packages/All/${PD_ALLOW_MAKE_JOBS_PACKAGES}"
 
   on_failure:
     show_error_log_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,8 +42,7 @@ setup_task:
 
     # define common variavles used in *_script. remember to export variables
     # at the end of this script.
-    PD_WORKDIR="/tmp"
-
+    PD_WORKDIR="$CIRRUS_WORKING_DIR}"
     PD_BASEFS="${PD_WORKDIR}/poudriere"
     PD_CCACHE_DIR=/var/cache/ccache
     PD_REQUIRED_PACKAGES="ports-mgmt/poudriere-devel ports-mgmt/portshaker ports-mgmt/portshaker-config git-lite"
@@ -169,9 +168,6 @@ setup_task:
     # ensure DISTFILES_CACHE exists
     mkdir -p "${PD_BASEFS}/ports/${PD_PORTS_NAME}/distfiles"
 
-  built_packages_cache:
-    folder: ${PD_BASEFS}/data/packages
-
   create_jail_script: |
 
     # cannot cache jails at the moment. see:
@@ -212,7 +208,7 @@ setup_task:
       # do NOT quote, wildcard
       for F in ${PD_BASEFS}/data/logs/bulk/${PD_BUILD_NAME}/latest/logs/errors/*.log; do
         echo "${F}"
-        cat ${F}
+        cat "${F}"
       done
   always:
     copy_log_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -151,7 +151,7 @@ setup_task:
     echo "Building ${ALL_ORIGIN}"
 
     # do NOT quote ALL_ORIGIN
-    poudriere bulk -j "${PD_BUILD_NAME}" -p "${PD_PORTS_NAME}" -t -C ${ALL_ORIGIN}
+    poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -t -C ${ALL_ORIGIN}
 
   on_failure:
     show_error_log_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -254,6 +254,7 @@ setup_task:
     mkdir -p "${PD_WORKDIR}/packages/${PD_JAIL_NAME}/All"
     D=`realpath "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/All"`
     cp ${D}/* "${PD_WORKDIR}/packages/${PD_JAIL_NAME}/All"
+    ls -al ${PD_WORKDIR}/packages/${PD_JAIL_NAME}
     for F in meta.conf meta.txz packagesite.txz; do
       F=`realpath "${PD_WORKDIR}/packages/${PD_JAIL_NAME}/${F}"`
       cp "${F}" "${PD_WORKDIR}/packages/${PD_JAIL_NAME}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -124,6 +124,12 @@ setup_task:
     DISTFILES_CACHE=${PD_BASEFS}/ports/${PD_PORTS_NAME}/distfiles
     CCACHE_DIR=${PD_CCACHE_DIR}
 
+    # increase MAX_FILES. crosstool-NG.sh tries to modify ulimit during the
+    # build, which is not allowed.
+    #
+    # crosstool-NG.sh: line 112: ulimit: open files: cannot modify limit: Operation not permitted
+    MAX_FILES=4096
+
     __EOF__
     cat /usr/local/etc/poudriere.conf
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,12 +48,13 @@ setup_task:
     PD_CCACHE_DIR=/var/cache/ccache
     PD_REQUIRED_PACKAGES="ports-mgmt/poudriere-devel ports-mgmt/portshaker ports-mgmt/portshaker-config git-lite"
 
-    # the branch to use for the FreeBSD ports tree
+    # the branch to use for the FreeBSD ports tree.
     # see https://github.com/freebsd/freebsd-ports/branches for available
     # branches
     PD_FREEBSD_PORTS_BRANCH="2021Q3"
 
-    # the branch to use for the FreeBSD package tree
+    # the branch to use for the FreeBSD package tree. the build fetches
+    # and installs packages required by PD_ALL_ORIGIN.
     # see https://pkg.freebsd.org/FreeBSD:13:amd64/ for available branches
     PD_FREEBSD_PACKAGE_BRANCH=quarterly
 
@@ -121,7 +122,7 @@ setup_task:
     FREEBSD_HOST=https://download.FreeBSD.org
     FLAVOR_DEFAULT_ALL=yes
     DISTFILES_CACHE=${PD_BASEFS}/ports/${PD_PORTS_NAME}/distfiles
-    PD_CCACHE_DIR=${PD_CCACHE_DIR}
+    CCACHE_DIR=${PD_CCACHE_DIR}
 
     __EOF__
     cat /usr/local/etc/poudriere.conf
@@ -185,19 +186,19 @@ setup_task:
     mkdir -p "${CIRRUS_WORKING_DIR}/logs"
 
     # create a list of all packages in the repository
-    ALL_ORIGIN=`echo */* | sed -e 's|/[[:space:]]| |g' -e 's|/$||'`
+    PD_ALL_ORIGIN=`echo */* | sed -e 's|/[[:space:]]| |g' -e 's|/$||'`
 
     poudriere ports -l
     poudriere jail -l
 
-    # build ALL_ORIGIN
-    echo "Building ${ALL_ORIGIN}"
+    # build PD_ALL_ORIGIN
+    echo "Building ${PD_ALL_ORIGIN}"
 
-    # do NOT quote ALL_ORIGIN
-    # use -b flag to pre-install binary packages on which ${ALL_ORIGIN}
+    # do NOT quote PD_ALL_ORIGIN
+    # use -b flag to pre-install binary packages on which ${PD_ALL_ORIGIN}
     # depends. it saves time by skipping depended builds. -b flag requires
     # ports-mgmt/poudriere-devel.
-    poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PACKAGE_BRANCH}" -t -C ${ALL_ORIGIN}
+    poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PACKAGE_BRANCH}" -t -C ${PD_ALL_ORIGIN}
 
   on_failure:
     show_error_log_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,7 +22,7 @@ setup_task:
     - freebsd_instance:
         image_family: freebsd-12-2
   define_common_variables_script: |
-    PD_BASEFS="/usr/local/poudriere"
+    PD_BASEFS="/tmp/poudriere"
     PD_REQUIRED_PACKAGES="ports-mgmt/poudriere ports-mgmt/portshaker ports-mgmt/portshaker-config git-lite"
 
     # e.g. 122
@@ -60,6 +60,8 @@ setup_task:
     uname -msr
     sysctl kern.osreldate
     env | sort
+    df -h
+    mount
 
     # configure _merged_ ports tree
     cat << __EOF__ > /usr/local/etc/portshaker.conf

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -259,7 +259,7 @@ build_task:
     ls -alR "${__PD_DEST}"
     du -cksh "${__PD_DEST}"
 
-  packages_artifacts: |
+  packages_artifacts:
 
     # can be downloaded at:
     # https://api.cirrus-ci.com/v1/artifact/build/<CIRRUS_BUILD_ID>/<ARTIFACTS_NAME>.zip
@@ -301,7 +301,7 @@ generate_repo_task:
     pkg repo "${CIRRUS_WORKING_DIR}/packages"
     ls -al "${CIRRUS_WORKING_DIR}/packages"
 
-  packages_artifacts: |
+  packages_artifacts:
     path: "packages/*"
 
 test_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,8 +22,15 @@ setup_task:
     - freebsd_instance:
         image_family: freebsd-12-2
   define_common_variables_script: |
-    PD_BASEFS="/tmp/poudriere"
+    PD_WORKDIR="/tmp"
+
+    PD_BASEFS="${PD_WORKDIR}/poudriere"
+    PD_CCACHE_DIR=/var/cache/ccache
     PD_REQUIRED_PACKAGES="ports-mgmt/poudriere ports-mgmt/portshaker ports-mgmt/portshaker-config git-lite"
+
+    # the branch to use for the FreeBSD ports tree.
+    # see https://github.com/freebsd/freebsd-ports/branches
+    PD_FREEBSD_PORTS_BRANCH="2021Q2"
 
     # e.g. 122
     PD_VERSION_SHORT=`uname -r | sed -e 's/-.*//' -e 's/\.//'`
@@ -45,7 +52,9 @@ setup_task:
     # not allowed. value should NOT be quoted (i.e. NOT `foo="bar buz"`. use
     # `foo=bar buz` instead).
     cat << __EOF__ >> ${CIRRUS_ENV}
+    PD_WORKDIR=${PD_WORKDIR}
     PD_BASEFS=${PD_BASEFS}
+    PD_CCACHE_DIR=${PD_CCACHE_DIR}
     PD_REQUIRED_PACKAGES=${PD_REQUIRED_PACKAGES}
     PD_VERSION_SHORT=${PD_VERSION_SHORT}
     PD_MACHINE=${PD_MACHINE}
@@ -53,6 +62,7 @@ setup_task:
     PD_JAIL_NAME=${PD_JAIL_NAME}
     PD_PORTS_NAME=${PD_PORTS_NAME}
     PD_BUILD_NAME=${PD_BUILD_NAME}
+    PD_FREEBSD_PORTS_BRANCH=${PD_FREEBSD_PORTS_BRANCH}
     __EOF__
     cat ${CIRRUS_ENV}
 
@@ -68,7 +78,7 @@ setup_task:
     mirror_base_dir="/var/cache/portshaker"
     ports_trees="${PD_PORTS_NAME}"
     default_ports_tree="${PD_BASEFS}/ports/${PD_PORTS_NAME}"
-    default_merge_from="github:freebsd:freebsd-ports:main github:${CIRRUS_REPO_OWNER}:${CIRRUS_REPO_NAME}:${CIRRUS_BRANCH}"
+    default_merge_from="github:freebsd:freebsd-ports:${PD_FREEBSD_PORTS_BRANCH} github:${CIRRUS_REPO_OWNER}:${CIRRUS_REPO_NAME}:${CIRRUS_BRANCH}"
     fail_on_conflict="y"
 
     __EOF__
@@ -81,6 +91,7 @@ setup_task:
     FREEBSD_HOST=https://download.FreeBSD.org
     FLAVOR_DEFAULT_ALL=yes
     DISTFILES_CACHE=${PD_BASEFS}/ports/${PD_PORTS_NAME}/distfiles
+    PD_CCACHE_DIR=${PD_CCACHE_DIR}
 
     __EOF__
     cat /usr/local/etc/poudriere.conf
@@ -101,12 +112,12 @@ setup_task:
     pkg install --yes ${PD_REQUIRED_PACKAGES}
 
   ports_tree_cache:
-    folder: /var/cache/portshaker/github_freebsd_freebsd-ports_main
+    folder: /var/cache/portshaker/github_freebsd_freebsd-ports_${PD_FREEBSD_PORTS_BRANCH}
     fingerprint_script:
-      - echo github_freebsd_freebsd-ports_main
+      - echo github_freebsd_freebsd-ports_${PD_FREEBSD_PORTS_BRANCH}
       - echo 20210909
     populate_script: |
-      time -h portshaker -u github:freebsd:freebsd-ports:main
+      time -h portshaker -u github:freebsd:freebsd-ports:${PD_FREEBSD_PORTS_BRANCH}
 
   ports_tree_install_script: |
     echo Updating "github:${CIRRUS_REPO_OWNER}:${CIRRUS_REPO_NAME}:${CIRRUS_BRANCH}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -250,13 +250,14 @@ build_task:
     poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PACKAGE_BRANCH}" -t -C "${PD_ORIGIN}"
   copy_packages_script: |
 
-    __PD_SRC="${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/.latest/All"
+    __PD_SRC="${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/.latest"
     __PD_DEST="${PD_WORKDIR}/packages/${PD_BUILD_NAME}"
 
     ls -alR "${__PD_SRC}"
     mkdir -p "${__PD_DEST}"
     cp -R "${__PD_SRC}"/*  "${__PD_DEST}"
     ls -alR "${__PD_DEST}"
+    du -cksh "${__PD_DEST}"
 
   packages_artifacts: |
 
@@ -265,7 +266,7 @@ build_task:
     # path: "packages/*"
     #
     # Error from upload stream: rpc error: code = Unknown desc =
-    path: "packages/*.txz"
+    path: "packages/*"
 
   on_failure:
     show_error_log_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -249,6 +249,15 @@ setup_task:
     # depends. it saves time by skipping depended builds. -b flag requires
     # ports-mgmt/poudriere-devel.
     poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PACKAGE_BRANCH}" -t -C "${PD_ORIGIN}"
+  copy_packages_script: |
+    mkdir -p "${PD_WORKDIR}/packages"
+    cp "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}" "${PD_WORKDIR}/packages/"
+
+  packages_artifacts: |
+
+    # can be downloaded at:
+    # https://api.cirrus-ci.com/v1/artifact/build/<CIRRUS_BUILD_ID>/<TASK_NAME>/<ARTIFACTS_NAME>.zip
+    path: "packages/*"
 
   on_failure:
     show_error_log_script: |
@@ -265,3 +274,4 @@ setup_task:
       cp ${PD_BASEFS}/data/logs/bulk/${PD_BUILD_NAME}/latest/logs/*.log "${CIRRUS_WORKING_DIR}/logs/"
     log_artifacts:
       path: "logs/*.log"
+      type: text/plain

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,11 +5,6 @@
 # * publish packages when releasing
 # * support quaterly/latest ports
 
-freebsd_instance:
-  cpu: 4
-  memory: 4
-  disk: 80
-
 env:
   HOME: /root
   PATH: /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
@@ -17,13 +12,21 @@ env:
 
 setup_task:
   matrix:
+    # XXX use compute_engine_instance, instead of freebsd_instance, which is a
+    # syntactic sugar. with freebsd_instance, disk parameter is ignored.
     - compute_engine_instance:
         image_project: freebsd-org-cloud-dev
         image: family/freebsd-13-0
         platform: freebsd
+        cpu: 4
+        memory: 4
         disk: 80
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_project: freebsd-org-cloud-dev
+        image: family/freebsd-12-2
+        platform: freebsd
+        cpu: 4
+        memory: 4
         disk: 80
   define_common_variables_script: |
     PD_WORKDIR="/tmp"
@@ -73,6 +76,8 @@ setup_task:
   setup_script: |
     uname -msr
     sysctl kern.osreldate
+    sysctl hw.ncpu
+    top -bP
     env | sort
     df -h
     mount

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ setup_task:
   # increase timeout_in. in most cases, build will not finish in 60m, which is
   # the default. the default is not documented at
   # https://cirrus-ci.org/guide/writing-tasks/, but at https://cirrus-ci.org/faq/
-  timeout_in: 120m
+  timeout_in: 240m
   define_common_variables_script: |
 
     # define common variavles used in *_script. remember to export variables

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -267,6 +267,7 @@ build_task:
     #
     # Error from upload stream: rpc error: code = Unknown desc =
     path: "packages/All/${PD_ALLOW_MAKE_JOBS_PACKAGES}"
+    type: application/octet-stream
 
   on_failure:
     show_error_log_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,6 +8,7 @@
 freebsd_instance:
   cpu: 4
   memory: 4
+  disk: 80
 
 env:
   HOME: /root

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,7 @@
 # * publish packages when releasing
 # * support quaterly/latest ports
 # * support other FreeBSD releases
+# * re-generate packagesite.txz
 #
 # known issues
 #
@@ -251,16 +252,13 @@ build_task:
     poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PACKAGE_BRANCH}" -t -C "${PD_ORIGIN}"
   copy_packages_script: |
 
-    mkdir -p "${PD_WORKDIR}/packages/${PD_JAIL_NAME}/All"
-    ls -alR     "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}"
-    D=`realpath "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/All"`
-    cp ${D}/* "${PD_WORKDIR}/packages/${PD_JAIL_NAME}/All"
-    ls -alR "${PD_WORKDIR}/packages/${PD_JAIL_NAME}"
-    for F in meta.conf meta.txz packagesite.txz; do
-      F=`realpath "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/${F}"`
-      cp "${F}" "${PD_WORKDIR}/packages/${PD_JAIL_NAME}"
-    done
-    ls -alR "${PD_WORKDIR}/packages"
+    __PD_SRC="${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/.latest"
+    __PD_DEST="${PD_WORKDIR}/packages/${PD_BUILD_NAME}"
+
+    ls -alR "${__PD_SRC}"
+    mkdir -p "${__PD_DEST}"
+    cp -R "${__PD_SRC}"/*  "${__PD_DEST}"
+    ls -alR "${__PD_DEST}"
 
   packages_artifacts: |
 
@@ -271,7 +269,6 @@ build_task:
   on_failure:
     show_error_log_script: |
 
-      # do NOT quote, wildcard
       for F in ${PD_BASEFS}/data/logs/bulk/${PD_BUILD_NAME}/latest/logs/errors/*.log; do
         echo "${F}"
         cat "${F}"
@@ -279,7 +276,6 @@ build_task:
   always:
     copy_log_script: |
 
-      # do NOT quote, wildcard
       cp ${PD_BASEFS}/data/logs/bulk/${PD_BUILD_NAME}/latest/logs/*.log "${CIRRUS_WORKING_DIR}/logs/"
     log_artifacts:
       path: "logs/*.log"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ env:
   PATH: /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
   USER: root
 
-setup_task:
+build_task:
   matrix:
     # XXX divide the CI into multiple per-package build using matrix. max
     # timeout_in for a single task is limited to two hours. because of that,
@@ -285,6 +285,8 @@ setup_task:
       type: text/plain
 
 test_task:
+  depends_on:
+    - build
   matrix:
     - compute_engine_instance:
         image_project: freebsd-org-cloud-dev

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,7 @@ setup_task:
   matrix:
     # XXX use compute_engine_instance, instead of freebsd_instance, which is a
     # syntactic sugar. with freebsd_instance, disk parameter is ignored.
+    # see https://github.com/cirruslabs/cirrus-ci-docs/issues/911
     - compute_engine_instance:
         image_project: freebsd-org-cloud-dev
         image: family/freebsd-13-0
@@ -28,12 +29,16 @@ setup_task:
         cpu: 4
         memory: 8
         disk: 80
+  # increase timeout_in. in most cases, build will not finish 60m, which is
+  # the default. the default is not documented at
+  # https://cirrus-ci.org/guide/writing-tasks/, but at https://cirrus-ci.org/faq/
+  timeout_in: 120m
   define_common_variables_script: |
     PD_WORKDIR="/tmp"
 
     PD_BASEFS="${PD_WORKDIR}/poudriere"
     PD_CCACHE_DIR=/var/cache/ccache
-    PD_REQUIRED_PACKAGES="ports-mgmt/poudriere ports-mgmt/portshaker ports-mgmt/portshaker-config git-lite"
+    PD_REQUIRED_PACKAGES="ports-mgmt/poudriere-devel ports-mgmt/portshaker ports-mgmt/portshaker-config git-lite"
 
     # the branch to use for the FreeBSD ports tree.
     # see https://github.com/freebsd/freebsd-ports/branches
@@ -173,7 +178,10 @@ setup_task:
     echo "Building ${ALL_ORIGIN}"
 
     # do NOT quote ALL_ORIGIN
-    poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -t -C ${ALL_ORIGIN}
+    # use -b flag to pre-install binary packages on which ${ALL_ORIGIN}
+    # depends. it saves time by skipping depended builds. -b flag requires
+    # ports-mgmt/poudriere-devel.
+    poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PORTS_BRANCH}" -t -C ${ALL_ORIGIN}
 
   on_failure:
     show_error_log_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,11 @@
 #   https://medium.com/cirruslabs/introducing-cirrus-terminal-a-simple-way-to-get-ssh-like-access-to-your-tasks-1def0449065d
 # * publish packages when releasing
 # * support quaterly/latest ports
+#
+# known issues
+#
+# * caching does not work as I wish. do not expect *_cache implementations are
+#   right.
 
 env:
   HOME: /root
@@ -40,9 +45,13 @@ setup_task:
     PD_CCACHE_DIR=/var/cache/ccache
     PD_REQUIRED_PACKAGES="ports-mgmt/poudriere-devel ports-mgmt/portshaker ports-mgmt/portshaker-config git-lite"
 
-    # the branch to use for the FreeBSD ports tree.
+    # the branch to use for the FreeBSD ports tree
     # see https://github.com/freebsd/freebsd-ports/branches
-    PD_FREEBSD_PORTS_BRANCH="2021Q2"
+    PD_FREEBSD_PORTS_BRANCH="2021Q3"
+
+    # the branch to use for the FreeBSD package tree
+    # see https://pkg.freebsd.org/FreeBSD:13:amd64/ for available branches
+    PD_FREEBSD_PACKAGE_BRANCH=quarterly
 
     # e.g. 122
     PD_VERSION_SHORT=`uname -r | sed -e 's/-.*//' -e 's/\.//'`
@@ -181,10 +190,11 @@ setup_task:
     # use -b flag to pre-install binary packages on which ${ALL_ORIGIN}
     # depends. it saves time by skipping depended builds. -b flag requires
     # ports-mgmt/poudriere-devel.
-    poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PORTS_BRANCH}" -t -C ${ALL_ORIGIN}
+    poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PACKAGE_BRANCH}" -t -C ${ALL_ORIGIN}
 
   on_failure:
     show_error_log_script: |
+
       # do NOT quote, wildcard
       for F in ${PD_BASEFS}/data/logs/bulk/${PD_BUILD_NAME}/latest/logs/errors/*.log; do
         echo "${F}"
@@ -192,6 +202,7 @@ setup_task:
       done
   always:
     copy_log_script: |
+
       # do NOT quote, wildcard
       cp ${PD_BASEFS}/data/logs/bulk/${PD_BUILD_NAME}/latest/logs/*.log "${CIRRUS_WORKING_DIR}/logs/"
     log_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@
 # * publish packages when releasing
 # * support quaterly/latest ports
 # * support other FreeBSD releases
-# * re-generate packagesite.txz
+# * sign the packages
 #
 # known issues
 #
@@ -252,7 +252,7 @@ build_task:
     poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PACKAGE_BRANCH}" -t -C "${PD_ORIGIN}"
   copy_packages_script: |
 
-    __PD_SRC="${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/.latest"
+    __PD_SRC="${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/.latest/All"
     __PD_DEST="${PD_WORKDIR}/packages/${PD_BUILD_NAME}"
 
     ls -alR "${__PD_SRC}"
@@ -281,9 +281,29 @@ build_task:
       path: "logs/*.log"
       type: text/plain
 
-test_task:
+generate_repo_task:
   depends_on:
     - build
+  matrix:
+    - compute_engine_instance:
+        image_project: freebsd-org-cloud-dev
+        image: family/freebsd-13-0
+        platform: freebsd
+
+  download_packages_script: |
+    fetch -o "${CIRRUS_WORKING_DIR}/packages.zip" \
+      "https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/packages.zip"
+    (cd ${CIRRUS_WORKING_DIR} && unzip packages.zip)
+    ls -al "${CIRRUS_WORKING_DIR}/packages"
+    pkg repo "${CIRRUS_WORKING_DIR}/packages"
+    ls -al "${CIRRUS_WORKING_DIR}/packages"
+
+  packages_artifacts: |
+    path: "packages/*"
+
+test_task:
+  depends_on:
+    - generate_packagesite_txz
   matrix:
     - compute_engine_instance:
         image_project: freebsd-org-cloud-dev
@@ -325,7 +345,7 @@ test_task:
     mkdir -p /usr/local/etc/pkg/repos
     cat < __EOF__ > /usr/local/etc/pkg/repos/local.conf
     local: {
-      URL: "file://${CIRRUS_WORKING_DIR}/packages/${PD_JAIL_NAME}"
+      URL: "file:///${CIRRUS_WORKING_DIR}/packages/${PD_JAIL_NAME}"
       ENABLED: yes
     }
     __EOF__

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -255,7 +255,7 @@ setup_task:
     D=`realpath "${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/All"`
     cp ${D}/* "${PD_WORKDIR}/packages/${PD_JAIL_NAME}/All"
     for F in meta.conf meta.txz packagesite.txz; do
-      F=`realpath "${D}/${F}"`
+      F=`realpath "${PD_WORKDIR}/packages/${PD_JAIL_NAME}/${F}"`
       cp "${F}" "${PD_WORKDIR}/packages/${PD_JAIL_NAME}"
     done
     ls -alR "${PD_WORKDIR}/packages"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,8 +19,10 @@ setup_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-13-0
+        disk: 80
     - freebsd_instance:
         image_family: freebsd-12-2
+        disk: 80
   define_common_variables_script: |
     PD_WORKDIR="/tmp"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -88,9 +88,13 @@ setup_task:
       - uname -msr
       - echo 20210909
     populate_script: |
+
+      # do NOT quote PD_REQUIRED_PACKAGES
       pkg fetch --dependencies --yes ${PD_REQUIRED_PACKAGES}
 
   required_packages_install_script: |
+
+    # do NOT quote PD_REQUIRED_PACKAGES
     pkg install --yes ${PD_REQUIRED_PACKAGES}
 
   ports_tree_cache:
@@ -102,17 +106,17 @@ setup_task:
       time -h portshaker -u github:freebsd:freebsd-ports:main
 
   ports_tree_install_script: |
-    echo Updating github:${CIRRUS_REPO_OWNER}:${CIRRUS_REPO_NAME}:${CIRRUS_BRANCH}
-    portshaker -u github:${CIRRUS_REPO_OWNER}:${CIRRUS_REPO_NAME}:${CIRRUS_BRANCH}
+    echo Updating "github:${CIRRUS_REPO_OWNER}:${CIRRUS_REPO_NAME}:${CIRRUS_BRANCH}"
+    portshaker -u "github:${CIRRUS_REPO_OWNER}:${CIRRUS_REPO_NAME}:${CIRRUS_BRANCH}"
 
     # create the merged ports tree
     time -h portshaker -M
 
     # create the merged ports tree
-    poudriere ports -c -p ${PD_PORTS_NAME} -M ${PD_BASEFS}/ports/${PD_PORTS_NAME} -m null
+    poudriere ports -c -p "${PD_PORTS_NAME}" -M "${PD_BASEFS}/ports/${PD_PORTS_NAME}" -m null
 
     # ensure DISTFILES_CACHE exists
-    mkdir -p ${PD_BASEFS}/ports/${PD_PORTS_NAME}/distfiles
+    mkdir -p "${PD_BASEFS}/ports/${PD_PORTS_NAME}/distfiles"
 
   built_packages_cache:
     folder: ${PD_BASEFS}/data/packages
@@ -124,7 +128,7 @@ setup_task:
     #
     # also, the size of ${PD_BASEFS}/jails is too big to cache, and
     # cirrus-ci refuses to cache
-    poudriere jail -c -j ${PD_JAIL_NAME} -m ftp -v ${PD_RELEASE_NAME}
+    poudriere jail -c -j "${PD_JAIL_NAME}" -m ftp -v "${PD_RELEASE_NAME}"
 
   build_script: |
 
@@ -134,7 +138,7 @@ setup_task:
     # "Right now only storing files under $CIRRUS_WORKING_DIR folder as
     # artifacts is supported with a total size limit of 1G for a community
     # task"
-    mkdir -p ${CIRRUS_WORKING_DIR}/logs
+    mkdir -p "${CIRRUS_WORKING_DIR}/logs"
 
     # create a list of all packages in the repository
     ALL_ORIGIN=`echo */* | sed -e 's|/[[:space:]]| |g' -e 's|/$||'`
@@ -143,17 +147,21 @@ setup_task:
     poudriere jail -l
 
     # build ALL_ORIGIN
-    echo Building ${ALL_ORIGIN}
-    poudriere bulk -j "${PD_VERSION_SHORT}${PD_MACHINE}" -p ${PD_PORTS_NAME} -t -C ${ALL_ORIGIN}
+    echo "Building ${ALL_ORIGIN}"
+
+    # do NOT quote ALL_ORIGIN
+    poudriere bulk -j "${PD_BUILD_NAME}" -p "${PD_PORTS_NAME}" -t -C ${ALL_ORIGIN}
 
   on_failure:
     show_error_log_script: |
+      # do NOT quote, wildcard
       for F in ${PD_BASEFS}/data/logs/bulk/${PD_BUILD_NAME}/latest/logs/errors/*.log; do
         echo "${F}"
         cat ${F}
       done
   always:
     copy_log_script: |
-      cp ${PD_BASEFS}/data/logs/bulk/${PD_BUILD_NAME}/latest/logs/*.log ${CIRRUS_WORKING_DIR}/logs/
+      # do NOT quote, wildcard
+      cp ${PD_BASEFS}/data/logs/bulk/${PD_BUILD_NAME}/latest/logs/*.log "${CIRRUS_WORKING_DIR}/logs/"
     log_artifacts:
       path: "logs/*.log"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -250,12 +250,12 @@ build_task:
     poudriere bulk -j "${PD_JAIL_NAME}" -p "${PD_PORTS_NAME}" -b "${PD_FREEBSD_PACKAGE_BRANCH}" -t -C "${PD_ORIGIN}"
   copy_packages_script: |
 
-    __PD_SRC="${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/.latest"
-    __PD_DEST="${PD_WORKDIR}/packages/${PD_BUILD_NAME}"
+    __PD_SRC="${PD_BASEFS}/data/packages/${PD_BUILD_NAME}/.latest/All"
+    __PD_DEST="${PD_WORKDIR}/packages/${PD_BUILD_NAME}/All"
 
     ls -alR "${__PD_SRC}"
     mkdir -p "${__PD_DEST}"
-    cp -R "${__PD_SRC}"/*  "${__PD_DEST}"
+    cp ${__PD_SRC}/${PD_ALLOW_MAKE_JOBS_PACKAGES}  "${__PD_DEST}"
     ls -alR "${__PD_DEST}"
     du -cksh "${__PD_DEST}"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,8 +17,10 @@ env:
 
 setup_task:
   matrix:
-    - freebsd_instance:
-        image_family: freebsd-13-0
+    - compute_engine_instance:
+        image_project: freebsd-org-cloud-dev
+        image: family/freebsd-13-0
+        platform: freebsd
         disk: 80
     - freebsd_instance:
         image_family: freebsd-12-2


### PR DESCRIPTION
`|` defines a multiline string, however, artifacts instruction [needs a map](https://cirrus-ci.org/guide/writing-tasks/#artifact-parsing) with fields like `path:` to work correctly.

See https://github.com/cirruslabs/cirrus-ci-docs/issues/913.