### PR TITLE
build all ports in the repository before building build devel/esp-llvm-embedded-toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,133 @@
+---
+name: Look for changed ports and built them
+on:
+  - push
+
+jobs:
+  list-ports:
+    runs-on: ubuntu-latest
+    outputs:
+      PORTS_TO_BUILD: ${{ steps.list-ports-to-build.outputs.PORTS_TO_BUILD }}
+      BUILD_ALL_PORTS: ${{ steps.build-all-ports.outputs.BUILD_ALL_PORTS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          list-files: shell
+          filters: |
+            ports-to-build:
+              - "[0-9a-zA-Z]*/**"
+            ci:
+              - ".github/workflows/*.yml"
+
+      - name: Build all ports in the repository
+        if: steps.filter.outputs.ci == 'true'
+        id: build-all-ports
+        run: |
+          echo "steps.filter.outputs.ci_files: '${{ steps.filter.outputs.ci_files }}'"
+          echo "::notice ::Building all the ports in the repository"
+
+          # find ports in the repository and make it a list of one line
+          # separated by a space.
+          PORTS_TO_BUILD=`find * -type d -maxdepth 1 -mindepth 1 | tr '\n' ' ' | sed -e 's/ $//'`
+
+          # pass the JSON to other jobs
+          echo "BUILD_ALL_PORTS=${PORTS_TO_BUILD}" >> "${GITHUB_OUTPUT}"
+          cat "${GITHUB_OUTPUT}"
+
+      - name: List ports-to-build
+        if: steps.filter.outputs.ports-to-build == 'true' && steps.filter.outputs.ci != 'true'
+        id: list-ports-to-build
+        run: |
+          echo "steps.filter.outputs.ports-to-build_files: '${{ steps.filter.outputs.ports-to-build_files }}'"
+
+          # find changed ports in the repository and make it a list of one
+          # line separated by a space.
+          for F in ${{ steps.filter.outputs.ports-to-build_files }}; do
+            PORTS_TO_BUILD="${PORTS_TO_BUILD} `echo ${F} | cut -f 1,2 -d '/' | sort -u | grep '/'`
+          done
+          PORTS_TO_BUILD=`echo ${PORTS_TO_BUILD} | tr '\n' ' ' | sed -e 's/ $//'`
+          echo "::notice ::Building ${PORTS_TO_BUILD}"
+
+          # pass the JSON to other jobs
+          echo "PORTS_TO_BUILD=${PORTS_TO_BUILD}" >> "${GITHUB_OUTPUT}"
+          cat "${GITHUB_OUTPUT}"
+
+  filter-devel-esp-llvm-embedded-toolchain:
+
+    # XXX devel/esp-llvm-embedded-toolchain depends on riscv32-esp-elf and xtensa-esp-elf.
+    # that means the two dependencies must be built before
+    # devel/esp-llvm-embedded-toolchain.  it takes more than 6 hours and the
+    # build is canceled. to avoid it, it is necessary:
+    #
+    # * to build the two
+    # * to cache the built packages
+    # * to build devel/esp-llvm-embedded-toolchain with the cache pre-filled
+    #
+    # in the first run, build all packages. in the second run, build
+    # devel/esp-llvm-embedded-toolchain
+    runs-on: ubuntu-latest
+    needs: list-ports
+    outputs:
+      PORTS_TO_BUILD: ${{ steps.filter.outputs.PORTS_TO_BUILD }}
+      PORTS_TO_BUILD_ORIG: ${{ steps.filter.outputs.PORTS_TO_BUILD_ORIG }}
+    steps:
+      - name: Filter devel/esp-llvm-embedded-toolchain from PORTS_TO_BUILD
+        id: filter
+        shell: sh
+        run: |
+          if [ ! -z "${{ needs.list-ports.outputs.BUILD_ALL_PORTS }}" ]; then
+            PORTS_TO_BUILD="${{ needs.list-ports.outputs.BUILD_ALL_PORTS }}"
+          elif [ ! -z "${{ needs.list-ports.outputs.PORTS_TO_BUILD }}" ]; then
+            PORTS_TO_BUILD="${{ needs.list-ports.outputs.PORTS_TO_BUILD }}"
+          else
+            echo "Building none"
+          fi
+          PORTS_TO_BUILD_ORIG="${PORTS_TO_BUILD}"
+          PORTS_TO_BUILD=`echo "${PORTS_TO_BUILD}" | \
+            tr ' ' '\n' | \
+            grep -v "devel/esp-llvm-embedded-toolchain" | \
+            tr '\n' ' ' | \
+            sed -e 's/ $//'`
+          echo "::notice ::Building ${PORTS_TO_BUILD}"
+          echo "PORTS_TO_BUILD=${PORTS_TO_BUILD}" >> "${GITHUB_OUTPUT}"
+          echo "PORTS_TO_BUILD_ORIG=${PORTS_TO_BUILD_ORIG}" >> "${GITHUB_OUTPUT}"
+          cat "${GITHUB_OUTPUT}"
+
+  build-ports:
+    name: Build ports (1st run)
+    needs: filter-devel-esp-llvm-embedded-toolchain
+    uses: ./.github/workflows/poudriere.yml
+    with:
+      ports-to-build: ${{ needs.filter-devel-esp-llvm-embedded-toolchain.outputs.PORTS_TO_BUILD }}
+
+  see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built:
+    name: See if devel/esp-llvm-embedded-toolchain needs to built
+    runs-on: ubuntu-latest
+    needs: filter-devel-esp-llvm-embedded-toolchain
+    outputs:
+      RESULT: ${{ steps.see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built.outputs.RESULT }}
+    steps:
+      - name: See if devel/esp-llvm-embedded-toolchain needs to be built
+        id: see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built
+        shell: sh
+        run: |
+          PORTS_TO_BUILD_ORIG="${{ needs.filter-devel-esp-llvm-embedded-toolchain.outputs.PORTS_TO_BUILD_ORIG }}"
+          RESULT=`echo "${PORTS_TO_BUILD_ORIG}" | tr ' ' '\n' | grep devel/esp-llvm-embedded-toolchain`
+          if [ -z "${RESULT}" ]; then
+            echo "RESULT=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+  build-devel-esp-llvm-embedded-toolchain:
+    name: Build devel/esp-llvm-embedded-toolchain (2nd run)
+    needs:
+      - see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built
+      - build-ports
+    if: ${{ needs.see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built.outputs.RESULT }}
+    uses: ./.github/workflows/poudriere.yml
+    with:
+      ports-to-build: devel/esp-llvm-embedded-toolchain

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
   see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built:
     name: See if devel/esp-llvm-embedded-toolchain needs to built
     runs-on: ubuntu-latest
-    needs: filter-devel-esp-llvm-embedded-toolchain
+    needs: build-ports
     outputs:
       RESULT: ${{ steps.see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built.outputs.RESULT }}
     steps:
@@ -124,9 +124,7 @@ jobs:
 
   build-devel-esp-llvm-embedded-toolchain:
     name: Build devel/esp-llvm-embedded-toolchain (2nd run)
-    needs:
-      - see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built
-      - build-ports
+    needs: see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built
     if: ${{ needs.see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built.outputs.RESULT }}
     uses: ./.github/workflows/poudriere.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,7 @@ jobs:
   list-ports:
     runs-on: ubuntu-latest
     outputs:
-      PORTS_TO_BUILD: ${{ steps.list-ports-to-build.outputs.PORTS_TO_BUILD }}
-      BUILD_ALL_PORTS: ${{ steps.build-all-ports.outputs.BUILD_ALL_PORTS }}
+      PORTS_TO_BUILD: ${{ steps.conclude-port-to-build.outputs.PORTS_TO_BUILD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,7 +23,7 @@ jobs:
             ci:
               - ".github/workflows/*.yml"
 
-      - name: Build all ports in the repository
+      - name: List CI files
         if: steps.filter.outputs.ci == 'true'
         id: build-all-ports
         run: |
@@ -36,10 +35,10 @@ jobs:
           PORTS_TO_BUILD=`find * -type d -maxdepth 1 -mindepth 1 | tr '\n' ' ' | sed -e 's/ $//'`
 
           # pass the JSON to other jobs
-          echo "BUILD_ALL_PORTS=${PORTS_TO_BUILD}" >> "${GITHUB_OUTPUT}"
+          echo "PORTS_TO_BUILD=${PORTS_TO_BUILD}" >> "${GITHUB_OUTPUT}"
           cat "${GITHUB_OUTPUT}"
 
-      - name: List ports-to-build
+      - name: List changed ports
         if: steps.filter.outputs.ports-to-build == 'true' && steps.filter.outputs.ci != 'true'
         id: list-ports-to-build
         run: |
@@ -57,77 +56,22 @@ jobs:
           echo "PORTS_TO_BUILD=${PORTS_TO_BUILD}" >> "${GITHUB_OUTPUT}"
           cat "${GITHUB_OUTPUT}"
 
-  filter-devel-esp-llvm-embedded-toolchain:
-
-    # XXX devel/esp-llvm-embedded-toolchain depends on riscv32-esp-elf and xtensa-esp-elf.
-    # that means the two dependencies must be built before
-    # devel/esp-llvm-embedded-toolchain.  it takes more than 6 hours and the
-    # build is canceled. to avoid it, it is necessary:
-    #
-    # * to build the two
-    # * to cache the built packages
-    # * to build devel/esp-llvm-embedded-toolchain with the cache pre-filled
-    #
-    # in the first run, build all packages. in the second run, build
-    # devel/esp-llvm-embedded-toolchain
-    runs-on: ubuntu-latest
-    needs: list-ports
-    outputs:
-      PORTS_TO_BUILD: ${{ steps.filter.outputs.PORTS_TO_BUILD }}
-      PORTS_TO_BUILD_ORIG: ${{ steps.filter.outputs.PORTS_TO_BUILD_ORIG }}
-    steps:
-      - name: Filter devel/esp-llvm-embedded-toolchain from PORTS_TO_BUILD
-        id: filter
+      - name: Conclude PORTS_TO_BUILD
         shell: sh
+        id: conclude-port-to-build
         run: |
-          if [ ! -z "${{ needs.list-ports.outputs.BUILD_ALL_PORTS }}" ]; then
-            PORTS_TO_BUILD="${{ needs.list-ports.outputs.BUILD_ALL_PORTS }}"
-          elif [ ! -z "${{ needs.list-ports.outputs.PORTS_TO_BUILD }}" ]; then
-            PORTS_TO_BUILD="${{ needs.list-ports.outputs.PORTS_TO_BUILD }}"
-          else
-            echo "Building none"
+          PORTS_TO_BUILD=""
+          if [ ! -z "${{ steps.build-all-ports.outputs.PORTS_TO_BUILD }}" ]; then
+            PORTS_TO_BUILD="${{ steps.build-all-ports.outputs.PORTS_TO_BUILD }}"
+          elif [ ! -z "${{ steps.list-ports-to-build.outputs.PORTS_TO_BUILD }}" ]; then
+            PORTS_TO_BUILD="${{ steps.list-ports-to-build.outputs.PORTS_TO_BUILD }}"
           fi
-          PORTS_TO_BUILD_ORIG="${PORTS_TO_BUILD}"
-          PORTS_TO_BUILD=`echo "${PORTS_TO_BUILD}" | \
-            tr ' ' '\n' | \
-            grep -v "devel/esp-llvm-embedded-toolchain" | \
-            tr '\n' ' ' | \
-            sed -e 's/ $//'`
-          echo "::notice ::Building ${PORTS_TO_BUILD}"
           echo "PORTS_TO_BUILD=${PORTS_TO_BUILD}" >> "${GITHUB_OUTPUT}"
-          echo "PORTS_TO_BUILD_ORIG=${PORTS_TO_BUILD_ORIG}" >> "${GITHUB_OUTPUT}"
           cat "${GITHUB_OUTPUT}"
 
   build-ports:
     name: Build ports (1st run)
-    needs: filter-devel-esp-llvm-embedded-toolchain
+    needs: list-ports
     uses: ./.github/workflows/poudriere.yml
     with:
-      ports-to-build: ${{ needs.filter-devel-esp-llvm-embedded-toolchain.outputs.PORTS_TO_BUILD }}
-
-  see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built:
-    name: See if devel/esp-llvm-embedded-toolchain needs to built
-    runs-on: ubuntu-latest
-    needs:
-      - build-ports
-      - filter-devel-esp-llvm-embedded-toolchain
-    outputs:
-      RESULT: ${{ steps.see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built.outputs.RESULT }}
-    steps:
-      - name: See if devel/esp-llvm-embedded-toolchain needs to be built
-        id: see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built
-        shell: sh
-        run: |
-          PORTS_TO_BUILD_ORIG="${{ needs.filter-devel-esp-llvm-embedded-toolchain.outputs.PORTS_TO_BUILD_ORIG }}"
-          RESULT=`echo "${PORTS_TO_BUILD_ORIG}" | tr ' ' '\n' | grep devel/esp-llvm-embedded-toolchain`
-          if [ -z "${RESULT}" ]; then
-            echo "RESULT=true" >> "${GITHUB_OUTPUT}"
-          fi
-
-  build-devel-esp-llvm-embedded-toolchain:
-    name: Build devel/esp-llvm-embedded-toolchain (2nd run)
-    needs: see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built
-    if: ${{ needs.see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built.outputs.RESULT }}
-    uses: ./.github/workflows/poudriere.yml
-    with:
-      ports-to-build: devel/esp-llvm-embedded-toolchain
+      ports-to-build: ${{ needs.list-ports.outputs.PORTS_TO_BUILD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,9 @@ jobs:
   see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built:
     name: See if devel/esp-llvm-embedded-toolchain needs to built
     runs-on: ubuntu-latest
-    needs: build-ports
+    needs:
+      - build-ports
+      - filter-devel-esp-llvm-embedded-toolchain
     outputs:
       RESULT: ${{ steps.see-if-devel-esp-llvm-embedded-toolchain-needs-to-be-built.outputs.RESULT }}
     steps:

--- a/.github/workflows/poudriere.yml
+++ b/.github/workflows/poudriere.yml
@@ -180,6 +180,9 @@ jobs:
             fi
 
             # pre-fill ccache cache
+            #
+            # TQODO install ccache when building the VM image
+            ASSUME_ALWAYS_YES=yes pkg install ccache
             if [ -d ccache ]; then
               ls -al ccache
               sudo rm -rf "${CCACHE_DIR}"

--- a/.github/workflows/poudriere.yml
+++ b/.github/workflows/poudriere.yml
@@ -90,11 +90,15 @@ jobs:
           path: packages
           if_no_artifact_found: warn
 
-      - name: tree packages
+      - name: Merge packages
         run: |
           if [ -d packages ]; then
-            tree packages
+            for D in `echo packages/*`; do
+              mv "${D}"/*.pkg packages/
+              rm -rf "${D}"
+            done
           fi
+          tree packages
 
       - name: Download ccache
         uses: dawidd6/action-download-artifact@v6
@@ -181,8 +185,8 @@ jobs:
             # pre-fill packages cache
             if [ -d packages ]; then
               ls -al packages
-              cp -R packages/* "/usr/local/poudriere/data/packages/${JAIL_NAME}-${PORTS_NAME}/All/"
-              rm -rf packages
+              sudo cp -R packages/* "/usr/local/poudriere/data/packages/${JAIL_NAME}-${PORTS_NAME}/All/"
+              sudo rm -rf packages
             fi
 
             # pre-fill ccache cache
@@ -268,41 +272,10 @@ jobs:
           echo "::warning ::building ${{ matrix.PORT }} failed to build. the logs are available at: https://github.com/${{ github.repository }}/actions/runs/${{ github.github.run_id }}/artifacts/${{ steps.packages-upload-step.outputs.artifact-id }}"
           fi
 
-  store-packages:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - name: Download built packages and merge them
-        uses: actions/download-artifact@v4
-        with:
-          pattern: packages-*
-          merge-multiple: true
-          path: packages
-
-      - name: List package cache
-        shell: sh
-        run: |
-          tree packages
-
-      - name: Create unique SHA-256 of inputs
-        id: sha256
-        shell: sh
-        run: |
-          PORTS_TO_BUILD_SHA256=`echo -n ${{ github.inputs.ports-to-build }} | sha256sum | cut -f 1 -d ' '`
-          echo "PORTS_TO_BUILD_SHA256=${PORTS_TO_BUILD_SHA256}" >> "${GITHUB_OUTPUT}"
-          cat "${GITHUB_OUTPUT}"
-
-      - name: Upload packages cache for future builds
-        uses: actions/upload-artifact@v4
-        with:
-          name: packages-cache-${{ steps.sha256.outputs.PORTS_TO_BUILD_SHA256 }}
-          path: packages
-
   conclude-result:
     runs-on: ubuntu-latest
     needs:
-      - store-packages
+      - build
     steps:
       - name: Download logs
         uses: actions/download-artifact@v4

--- a/.github/workflows/poudriere.yml
+++ b/.github/workflows/poudriere.yml
@@ -184,7 +184,7 @@ jobs:
               ls -al ccache
               sudo rm -rf "${CCACHE_DIR}"
               sudo mv ccache "${CCACHE_DIR}"
-              sudo chmod -R root:wheel "${CCACHE_DIR}"
+              sudo chown -R root:wheel "${CCACHE_DIR}"
 
               # set max_size to less than 2GB.
               # dawidd6/action-download-artifact has 2GB limit in size.

--- a/.github/workflows/poudriere.yml
+++ b/.github/workflows/poudriere.yml
@@ -1,5 +1,5 @@
 ---
-name: Build all ports in the repository
+name: Build ports in the repository
 
 # this workflow works when:
 #
@@ -15,38 +15,35 @@ name: Build all ports in the repository
 # the VM image and the script to build it can be found at:
 # https://github.com/trombik/freebsd-builder-poudriere
 on:
-  - push
+  workflow_call:
+    inputs:
+      ports-to-build:
+        description: space separated `category/name`
+        required: true
+        type: string
+
 env:
    BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
-  list-ports:
+  convert:
     runs-on: ubuntu-latest
     outputs:
-      PORTS_TO_BUILD_JSON: ${{ steps.list_ports_to_build.outputs.PORTS_TO_BUILD_JSON }}
+      PORTS_TO_BUILD_JSON: ${{ steps.to-json.outputs.PORTS_TO_BUILD_JSON }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Create a list of ports to build
-        id: list_ports_to_build
+      - name: Convert input to JSON
+        id: to-json
         shell: sh
         run: |
-
-          # find ports in the repository and make it a list of one line
-          # separated by a space.
-          PORTS_TO_BUILD=`find * -type d -maxdepth 1 -mindepth 1 | tr '\n' ' ' | sed -e 's/ $//'`
-
-          # create a JSON from the list
-          PORTS_TO_BUILD_JSON=`jq -n -c -M --arg V "${PORTS_TO_BUILD}" '{ PORT: ($V | split(" ")) }'`
-
-          # pass the JSON to other jobs
+          echo "${{ inputs.ports-to-build }}"
+          PORTS_TO_BUILD_JSON=`jq -n -c -M --arg V "${{ inputs.ports-to-build }}" '{ PORT: ($V | split(" ")) }'`
           echo "PORTS_TO_BUILD_JSON=${PORTS_TO_BUILD_JSON}" >> "${GITHUB_OUTPUT}"
           cat "${GITHUB_OUTPUT}"
+
   build:
     runs-on: ubuntu-latest
     needs:
-      - list-ports
+      - convert
     strategy:
 
       # use matrix so that the total time of build does not exceed max job (6
@@ -54,7 +51,7 @@ jobs:
       # https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration
       #
       # each job builds one port in the repository
-      matrix: ${{ fromJSON(needs.list-ports.outputs.PORTS_TO_BUILD_JSON) }}
+      matrix: ${{ fromJSON(needs.convert.outputs.PORTS_TO_BUILD_JSON) }}
 
       # do not cancel other jobs in the matrix when a job fails.
       fail-fast: false

--- a/.github/workflows/poudriere.yml
+++ b/.github/workflows/poudriere.yml
@@ -97,7 +97,7 @@ jobs:
           # download ccache cache from previous workflow run
           workflow: poudriere.yml
           workflow_conclusion: completed
-          name: ccache-cache-${{ env.SAFE_PORT_NAME }}
+          name: ccache-${{ env.SAFE_PORT_NAME }}
           path: ccache
           if_no_artifact_found: warn
 

--- a/.github/workflows/poudriere.yml
+++ b/.github/workflows/poudriere.yml
@@ -85,10 +85,16 @@ jobs:
           # download packages cache from previous workflow run
           workflow: poudriere.yml
           workflow_conclusion: completed
-          name: packages-cache-.*
+          name: packages-.*
           name_is_regexp: true
           path: packages
           if_no_artifact_found: warn
+
+      - name: tree packages
+        run: |
+          if [ -d packages ]; then
+            tree packages
+          fi
 
       - name: Download ccache
         uses: dawidd6/action-download-artifact@v6

--- a/.github/workflows/poudriere.yml
+++ b/.github/workflows/poudriere.yml
@@ -182,7 +182,7 @@ jobs:
             # pre-fill ccache cache
             #
             # TQODO install ccache when building the VM image
-            ASSUME_ALWAYS_YES=yes pkg install ccache
+            sudo env ASSUME_ALWAYS_YES=yes pkg install ccache
             if [ -d ccache ]; then
               ls -al ccache
               sudo rm -rf "${CCACHE_DIR}"

--- a/.github/workflows/poudriere.yml
+++ b/.github/workflows/poudriere.yml
@@ -85,7 +85,8 @@ jobs:
           # download packages cache from previous workflow run
           workflow: poudriere.yml
           workflow_conclusion: completed
-          name: packages-cache
+          name: packages-cache-.*
+          name_is_regexp: true
           path: packages
           if_no_artifact_found: warn
 
@@ -275,10 +276,17 @@ jobs:
         run: |
           tree packages
 
+      - name: Create unique SHA-256 of inputs
+        id: sha256
+        shell: sh
+        run: |
+          PORTS_TO_BUILD_SHA256=`echo -n ${{ github.inputs.ports-to-build }} | sha256sum`
+          echo "$PORTS_TO_BUILD_SHA256=${PORTS_TO_BUILD_SHA256}" >> "${GITHUB_OUTPUT}"
+
       - name: Upload packages cache for future builds
         uses: actions/upload-artifact@v4
         with:
-          name: packages-cache
+          name: packages-cache--${{ steps.sha256.outputs.PORTS_TO_BUILD_SHA256 }}
           path: packages
 
   conclude-result:

--- a/.github/workflows/poudriere.yml
+++ b/.github/workflows/poudriere.yml
@@ -284,7 +284,8 @@ jobs:
         shell: sh
         run: |
           PORTS_TO_BUILD_SHA256=`echo -n ${{ github.inputs.ports-to-build }} | sha256sum`
-          echo "$PORTS_TO_BUILD_SHA256=${PORTS_TO_BUILD_SHA256}" >> "${GITHUB_OUTPUT}"
+          echo "PORTS_TO_BUILD_SHA256=${PORTS_TO_BUILD_SHA256}" >> "${GITHUB_OUTPUT}"
+          cat "${GITHUB_OUTPUT}"
 
       - name: Upload packages cache for future builds
         uses: actions/upload-artifact@v4
@@ -308,12 +309,15 @@ jobs:
         shell: sh
         run: |
           EXIT_STATUS=0
+          ERROR_LOG_FILES=""
+          FAILED_PACKAGES=""
           tree logs
 
           # logs under `errors` are files, not symlinks
-          ERROR_LOG_FILES=`[ -d logs/errors ] && find logs/errors -type f -name '*.log'`
+          if [ -d logs/errors ]; then
+            ERROR_LOG_FILES=`find logs/errors -type f -name '*.log'`
+          fi
           echo "ERROR_LOG_FILES: ${ERROR_LOG_FILES}"
-          FAILED_PACKAGES=""
           for F in ${ERROR_LOG_FILES}; do
             FAILED_PACKAGE=`basename "${F}" | sed -e 's/\.log//'`
             FAILED_PACKAGES="${FAILED_PACKAGES} ${FAILED_PACKAGE}"

--- a/.github/workflows/poudriere.yml
+++ b/.github/workflows/poudriere.yml
@@ -290,7 +290,7 @@ jobs:
       - name: Upload packages cache for future builds
         uses: actions/upload-artifact@v4
         with:
-          name: packages-cache--${{ steps.sha256.outputs.PORTS_TO_BUILD_SHA256 }}
+          name: packages-cache-${{ steps.sha256.outputs.PORTS_TO_BUILD_SHA256 }}
           path: packages
 
   conclude-result:

--- a/.github/workflows/poudriere.yml
+++ b/.github/workflows/poudriere.yml
@@ -283,7 +283,7 @@ jobs:
         id: sha256
         shell: sh
         run: |
-          PORTS_TO_BUILD_SHA256=`echo -n ${{ github.inputs.ports-to-build }} | sha256sum`
+          PORTS_TO_BUILD_SHA256=`echo -n ${{ github.inputs.ports-to-build }} | sha256sum | cut -f 1 -d ' '`
           echo "PORTS_TO_BUILD_SHA256=${PORTS_TO_BUILD_SHA256}" >> "${GITHUB_OUTPUT}"
           cat "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/poudriere.yml
+++ b/.github/workflows/poudriere.yml
@@ -299,8 +299,8 @@ jobs:
           EXIT_STATUS=0
           tree logs
 
-          # logs under `errors` are symlink, not file
-          ERROR_LOG_FILES=`find logs/errors -type l -name '*.log'`
+          # logs under `errors` are files, not symlinks
+          ERROR_LOG_FILES=`[ -d logs/errors ] && find logs/errors -type f -name '*.log'`
           echo "ERROR_LOG_FILES: ${ERROR_LOG_FILES}"
           FAILED_PACKAGES=""
           for F in ${ERROR_LOG_FILES}; do

--- a/devel/xtensa-esp-elf/Makefile
+++ b/devel/xtensa-esp-elf/Makefile
@@ -137,6 +137,14 @@ EXTRACT_ONLY+=	${DISTNAME}${EXTRACT_SUFX} \
 	espressif-binutils-gdb-${ESPRESSIF_BINUTILS_TAG}_GH0.tar.gz \
 	espressif-newlib-esp32-${ESPRESSIF_NEWLIB_TAG}_GH0.tar.gz
 
+# directories under ${WRKDIR} to remove before do-install target.
+# XXX on GitHub Actions runners, disk space is limited and the build fails
+# during do-install. Remeving these directories saves 1.6 GB.
+ESP_REMOVE_BEFORE_DO_INSTALL=	\
+	espressif-gcc-${ESPRESSIF_GCC_TAG} \
+	espressif-binutils-gdb-${ESPRESSIF_BINUTILS_TAG} \
+	espressif-newlib-esp32-${ESPRESSIF_NEWLIB_TAG}
+
 PATCHDIR=		${MASTERDIR}/files/${FLAVOR}
 XTENSA_ROOT_DIR=	${PORTNAME}-${FLAVOR}
 
@@ -277,6 +285,18 @@ do-build:
 	${RM} ${BUILD_WRKSRC}/builds/${PORTNAME}/build.log.bz2 \
 		${BUILD_WRKSRC}/builds/${PORTNAME}/lib/charset.alias
 	${FIND} ${BUILD_WRKSRC}/builds/${PORTNAME} -type d | ${XARGS} ${CHMOD} -w
+
+pre-install:
+	@${ECHO_MSG} "===>   Removing ESP_REMOVE_BEFORE_DO_INSTALL"
+	@${ECHO_MSG} "===>   Before"
+	@/bin/df -h -t ufs
+.for D in ${ESP_REMOVE_BEFORE_DO_INSTALL}
+	@if [ -d ${WRKDIR}/${D} ]; then \
+		${RM} -r ${WRKDIR}/${D}; \
+	fi
+.endfor
+	@${ECHO_MSG} "===>   After"
+	@/bin/df -h -t ufs
 
 do-install:
 	cd ${BUILD_WRKSRC}/builds && \


### PR DESCRIPTION
`devel/esp-llvm-embedded-toolchain` depends on `devel/xtensa-esp-elf` and `devel/riscv32-esp-elf`. which is a dependency on packages in the repository. `poudriere -b` does not help because the official packages tree does not have the packages. As a result, to build  `devel/esp-llvm-embedded-toolchain`, the build process build `devel/xtensa-esp-elf` and `devel/riscv32-esp-elf` before building `devel/esp-llvm-embedded-toolchain`, which requires more time (one hour for each, two hours in total) to build `devel/esp-llvm-embedded-toolchain`.

Before this fix, the job to build `devel/esp-llvm-embedded-toolchain` takes more than 6 hours, and is killed. This PR is supposed to build `devel/esp-llvm-embedded-toolchain`  within 6 hours.